### PR TITLE
Addition and correction of Japanese translation.

### DIFF
--- a/src/languages/ja.json5
+++ b/src/languages/ja.json5
@@ -10,7 +10,7 @@
     "scroll": {
         hint: 'Verb. As in scrolling a page.',
         original: 'Scroll',
-        value: '',
+        value: 'スクロール',
     },
     donate: {
         original: 'Donate',
@@ -1064,7 +1064,7 @@
     },
     'text-instruction': {
         original: 'Click canvas to place text',
-        value: 'クリックしてテキストを入力'
+        value: 'クリックしてテキストを入力。'
     },
     'text-title': {
         original: 'Add Text',
@@ -1116,7 +1116,7 @@
     },
     'submit-title': {
         original: 'Submit Drawing',
-        value: '処理しています。'
+        value: '画像を送信します。'
     },
     'submit-prompt': {
         original: 'Submit drawing?',

--- a/src/languages/ja.json5
+++ b/src/languages/ja.json5
@@ -356,7 +356,7 @@
     'file-no-autosave': {
         hint: "let user know they can't autosave, and there's no cloud storage. Keep short so fits on one line",
         original: 'No autosave, no cloud storage',
-        value: '自動保存された画像はありません'
+        value: 'クラウドに自動保存できません'
     },
     'file-new': {
         original: 'New',


### PR DESCRIPTION
 ```
"scroll": {
        hint: 'Verb. As in scrolling a page.',
        original: 'Scroll',
        value: 'スクロール',
    },
```
I couldn't see the scroll button on the screen, but the Japanese katakana "スクロール"(scroll) is probably correct for the translation from the word.
Please let me know if there is a way to check the actual screen.

If you have different opinions about these translations, please let us know.