### PR TITLE
Additions and corrections for Japanese and Chinese translations

### DIFF
--- a/src/languages/ja.json5
+++ b/src/languages/ja.json5
@@ -1105,20 +1105,20 @@
     'save-reminder-title': {
         hint: 'Save Reminder is a popup that shows up after 20 minutes of not saving. Allows user to save on the spot.',
         original: 'Unsaved Work',
-        value: ''
+        value: '作業を保存していません。'
     },
     'save-reminder-text': {
         hint: 'turns into: "...saved in <strong>12 minutes</strong>. Save..."',
         original: 'Image was not saved in {a} minutes{b}. Save now to prevent eventual loss.',
-        value: ''
+        value: '画像は{a}分間{b}保存されませんでした。作業を失わないように今すぐ保存してください。'
     },
     'save-reminder-save-psd': {
         original: 'Save As PSD',
-        value: ''
+        value: 'PSDで保存。'
     },
     'save-reminder-psd-layers': {
         original: 'PSD will remember all layers.',
-        value: ''
+        value: 'PSDは全レイヤーを保持します。'
     },
     submit: {
         original: 'Submit',

--- a/src/languages/zh-CN.json5
+++ b/src/languages/zh-CN.json5
@@ -14,7 +14,7 @@
     },
     donate: {
         original: 'Donate',
-        value: '$ 支持'
+        value: '赞助'
     },
     home: {
         hint: 'button with logo, top left of tools',
@@ -102,11 +102,11 @@
     },
     'brush-size': {
         original: 'Size',
-        value: '粗细'
+        value: '画笔大小'
     },
     'brush-blending': {
         original: 'Blending',
-        value: '湿润度'
+        value: '水分量'
     },
     'brush-toggle-pressure': {
         original: 'Toggle Pressure Sensitivity',
@@ -388,7 +388,7 @@
     },
     'file-copy-title': {
         original: 'Copy To Clipboard',
-        value: '复制到粘贴板'
+        value: '复制至剪贴板'
     },
     'file-share': {
         hint: 'Common feature on phones. Pressing share button allows to send data to a different app, e.g. as a text message to someone.',
@@ -548,7 +548,7 @@
     },
     'upload-title': {
         original: 'Upload to Imgur',
-        value: '上传到Imgur'
+        value: '上传至Imgur'
     },
     'upload-link-notice': {
         original: 'Anyone with the link to your uploaded image will be able to view it.',
@@ -596,7 +596,7 @@
     },
     'cropcopy-title-copy': {
         original: 'Copy To Clipboard',
-        value: '复制到粘贴板'
+        value: '复制至剪贴板'
     },
     'cropcopy-title-crop': {
         hint: 'Cropping is a common feature in image editing.',
@@ -609,7 +609,7 @@
     },
     'cropcopy-copied': {
         original: 'Copied.',
-        value: '已粘贴'
+        value: '已复制'
     },
     'cropcopy-btn-crop': {
         original: 'Apply Crop',
@@ -822,7 +822,7 @@
     },
     'filter-curves-description': {
         original: 'Apply curves on the selected layer.',
-        value: '应用曲线到已选图层。'
+        value: '应用曲线至已选图层。'
     },
     'filter-curves-all': {
         original: 'All',
@@ -854,7 +854,7 @@
     },
     'filter-tilt-shift-description': {
         original: 'Applies tilt shift on the selected layer.',
-        value: '应用移轴到已选图层。'
+        value: '应用移轴至已选图层。'
     },
     'filter-tilt-shift-blur': {
         original: 'Blur Radius',
@@ -890,7 +890,7 @@
     },
     'filter-triangle-blur-description': {
         original: 'Applies triangle blur on the selected layer.',
-        value: '应用模糊到已选图层。'
+        value: '应用模糊至已选图层。'
     },
     'filter-unsharp-mask-title': {
         original: 'Unsharp Mask',
@@ -898,7 +898,7 @@
     },
     'filter-unsharp-mask-description': {
         original: 'Sharpens the selected layer by scaling pixels away from the average of their neighbors.',
-        value: '根据附近像素的均值应用锐化到已选图层。'
+        value: '根据附近像素的均值应用锐化至已选图层。'
     },
     'filter-unsharp-mask-strength': {
         original: 'Strength',
@@ -934,7 +934,7 @@
     },
     'import-as-layer-limit-reached': {
         original: 'Layer limit reached. Image will be placed on existing layer.',
-        value: '达到图层数量上限。图像将会应用到已有图层。'
+        value: '达至图层数量上限。图像将会应用至已有图层。'
     },
     'import-as-layer-fit': {
         hint: 'verb. imported image made to fit inside canvas.',
@@ -1122,19 +1122,19 @@
     },
     submit: {
         original: 'Submit',
-        value: '提交'
+        value: '送出'
     },
     'submit-title': {
         original: 'Submit Drawing',
-        value: '提交作品'
+        value: '送出作品'
     },
     'submit-prompt': {
         original: 'Submit drawing?',
-        value: '确认提交？'
+        value: '确认送出？'
     },
     'submit-submitting': {
         original: 'Submitting',
-        value: '提交中'
+        value: '送出中'
     },
     'embed-init-loading': {
         original: 'Loading app',

--- a/src/languages/zh-CN.json5
+++ b/src/languages/zh-CN.json5
@@ -388,7 +388,7 @@
     },
     'file-copy-title': {
         original: 'Copy To Clipboard',
-        value: '复制至剪贴板'
+        value: '复制到剪贴板'
     },
     'file-share': {
         hint: 'Common feature on phones. Pressing share button allows to send data to a different app, e.g. as a text message to someone.',
@@ -548,7 +548,7 @@
     },
     'upload-title': {
         original: 'Upload to Imgur',
-        value: '上传至Imgur'
+        value: '上传到Imgur'
     },
     'upload-link-notice': {
         original: 'Anyone with the link to your uploaded image will be able to view it.',
@@ -596,7 +596,7 @@
     },
     'cropcopy-title-copy': {
         original: 'Copy To Clipboard',
-        value: '复制至剪贴板'
+        value: '复制到剪贴板'
     },
     'cropcopy-title-crop': {
         hint: 'Cropping is a common feature in image editing.',
@@ -822,7 +822,7 @@
     },
     'filter-curves-description': {
         original: 'Apply curves on the selected layer.',
-        value: '应用曲线至已选图层。'
+        value: '应用曲线到已选图层。'
     },
     'filter-curves-all': {
         original: 'All',
@@ -854,7 +854,7 @@
     },
     'filter-tilt-shift-description': {
         original: 'Applies tilt shift on the selected layer.',
-        value: '应用移轴至已选图层。'
+        value: '应用移轴到已选图层。'
     },
     'filter-tilt-shift-blur': {
         original: 'Blur Radius',
@@ -890,7 +890,7 @@
     },
     'filter-triangle-blur-description': {
         original: 'Applies triangle blur on the selected layer.',
-        value: '应用模糊至已选图层。'
+        value: '应用模糊到已选图层。'
     },
     'filter-unsharp-mask-title': {
         original: 'Unsharp Mask',
@@ -898,7 +898,7 @@
     },
     'filter-unsharp-mask-description': {
         original: 'Sharpens the selected layer by scaling pixels away from the average of their neighbors.',
-        value: '根据附近像素的均值应用锐化至已选图层。'
+        value: '根据附近像素的均值应用锐化到已选图层。'
     },
     'filter-unsharp-mask-strength': {
         original: 'Strength',
@@ -934,7 +934,7 @@
     },
     'import-as-layer-limit-reached': {
         original: 'Layer limit reached. Image will be placed on existing layer.',
-        value: '达至图层数量上限。图像将会应用至已有图层。'
+        value: '达到图层数量上限。图像将会应用到已有图层。'
     },
     'import-as-layer-fit': {
         hint: 'verb. imported image made to fit inside canvas.',
@@ -1122,19 +1122,19 @@
     },
     submit: {
         original: 'Submit',
-        value: '送出'
+        value: '提交'
     },
     'submit-title': {
         original: 'Submit Drawing',
-        value: '送出作品'
+        value: '提交作品'
     },
     'submit-prompt': {
         original: 'Submit drawing?',
-        value: '确认送出？'
+        value: '确认提交？'
     },
     'submit-submitting': {
         original: 'Submitting',
-        value: '送出中'
+        value: '提交中'
     },
     'embed-init-loading': {
         original: 'Loading app',

--- a/src/languages/zh-TW.json5
+++ b/src/languages/zh-TW.json5
@@ -388,7 +388,7 @@
     },
     'file-copy-title': {
         original: 'Copy To Clipboard',
-        value: '複製至剪貼簿'
+        value: '複製到剪貼板'
     },
     'file-share': {
         hint: 'Common feature on phones. Pressing share button allows to send data to a different app, e.g. as a text message to someone.',
@@ -548,7 +548,7 @@ filled: {
     },
     'upload-title': {
         original: 'Upload to Imgur',
-        value: '上傳至Imgur'
+        value: '上傳到Imgur'
     },
     'upload-link-notice': {
         original: 'Anyone with the link to your uploaded image will be able to view it.',
@@ -596,7 +596,7 @@ filled: {
     },
     'cropcopy-title-copy': {
         original: 'Copy To Clipboard',
-        value: '複製至剪貼簿'
+        value: '複製到剪貼板'
     },
     'cropcopy-title-crop': {
         hint: 'Cropping is a common feature in image editing.',
@@ -605,7 +605,7 @@ filled: {
     },
     'cropcopy-btn-copy': {
         original: 'To Clipboard',
-        value: '至剪貼簿'
+        value: '至剪貼板'
     },
     'cropcopy-copied': {
         original: 'Copied.',
@@ -822,7 +822,7 @@ filled: {
     },
     'filter-curves-description': {
         original: 'Apply curves on the selected layer.',
-        value: '應用曲線至已選圖層。 '
+        value: '應用曲線到已選圖層。 '
     },
     'filter-curves-all': {
         original: 'All',
@@ -854,7 +854,7 @@ filled: {
     },
     'filter-tilt-shift-description': {
         original: 'Applies tilt shift on the selected layer.',
-        value: '應用移軸至已選圖層。 '
+        value: '應用移軸到已選圖層。 '
     },
     'filter-tilt-shift-blur': {
         original: 'Blur Radius',
@@ -890,7 +890,7 @@ filled: {
     },
 'filter-triangle-blur-description': {
         original: 'Applies triangle blur on the selected layer.',
-        value: '應用模糊至已選圖層。 '
+        value: '應用模糊到已選圖層。 '
     },
     'filter-unsharp-mask-title': {
         original: 'Unsharp Mask',
@@ -898,7 +898,7 @@ filled: {
     },
     'filter-unsharp-mask-description': {
         original: 'Sharpens the selected layer by scaling pixels away from the average of their neighbors.',
-        value: '根據附近像素的均值應用銳化至已選圖層。 '
+        value: '根據附近像素的均值應用銳化到已選圖層。 '
     },
     'filter-unsharp-mask-strength': {
         original: 'Strength',
@@ -934,7 +934,7 @@ filled: {
     },
     'import-as-layer-limit-reached': {
         original: 'Layer limit reached. Image will be placed on existing layer.',
-        value: '達至圖層數量上限。圖像將會應用至已有圖層。 '
+        value: '達到圖層數量上限。圖像將會應用到已有圖層。'
     },
     'import-as-layer-fit': {
         hint: 'verb. imported image made to fit inside canvas.',
@@ -1122,19 +1122,19 @@ filled: {
     },
     submit: {
         original: 'Submit',
-        value: '送出'
+        value: '提交'
     },
     'submit-title': {
         original: 'Submit Drawing',
-        value: '送出圖像'
+        value: '提交圖像'
     },
     'submit-prompt': {
         original: 'Submit drawing?',
-        value: '確認送出？'
+        value: '確認提交？'
     },
     'submit-submitting': {
         original: 'Submitting',
-        value: '送出中'
+        value: '提交中'
     },
     'embed-init-loading': {
         original: 'Loading app',

--- a/src/languages/zh-TW.json5
+++ b/src/languages/zh-TW.json5
@@ -1122,19 +1122,19 @@ filled: {
     },
     submit: {
         original: 'Submit',
-        value: '提交'
+        value: '送出'
     },
     'submit-title': {
         original: 'Submit Drawing',
-        value: '提交圖像'
+        value: '送出圖像'
     },
     'submit-prompt': {
         original: 'Submit drawing?',
-        value: '確認提交？'
+        value: '確認送出？'
     },
     'submit-submitting': {
         original: 'Submitting',
-        value: '提交中'
+        value: '送出中'
     },
     'embed-init-loading': {
         original: 'Loading app',

--- a/src/languages/zh-TW.json5
+++ b/src/languages/zh-TW.json5
@@ -102,7 +102,7 @@
     },
     'brush-size': {
         original: 'Size',
-        value: '筆刷尺寸'
+        value: '画笔大小'
     },
     'brush-blending': {
         original: 'Blending',
@@ -1105,20 +1105,20 @@ filled: {
     'save-reminder-title': {
         hint: 'Save Reminder is a popup that shows up after 20 minutes of not saving. Allows user to save on the spot.',
         original: 'Unsaved Work',
-        value: ''
+        value: '作品未保存'
     },
     'save-reminder-text': {
         hint: 'turns into: "...saved in <strong>12 minutes</strong>. Save..."',
         original: 'Image was not saved in {a} minutes{b}. Save now to prevent eventual loss.',
-        value: ''
+        value: '圖畫已{a}分鐘{b}未保存。立刻保存以避免進度丟失。'
     },
     'save-reminder-save-psd': {
         original: 'Save As PSD',
-        value: ''
+        value: 保存為PSD'
     },
     'save-reminder-psd-layers': {
         original: 'PSD will remember all layers.',
-        value: ''
+        value: 'PSD可保留所有圖層。'
     },
     submit: {
         original: 'Submit',

--- a/src/languages/zh-TW.json5
+++ b/src/languages/zh-TW.json5
@@ -1114,7 +1114,7 @@ filled: {
     },
     'save-reminder-save-psd': {
         original: 'Save As PSD',
-        value: 保存為PSD'
+        value: '保存為PSD'
     },
     'save-reminder-psd-layers': {
         original: 'PSD will remember all layers.',

--- a/src/languages/zh-TW.json5
+++ b/src/languages/zh-TW.json5
@@ -102,7 +102,7 @@
     },
     'brush-size': {
         original: 'Size',
-        value: '画笔大小'
+        value: '畫筆大小'
     },
     'brush-blending': {
         original: 'Blending',

--- a/src/languages/zh-TW.json5
+++ b/src/languages/zh-TW.json5
@@ -356,7 +356,7 @@
     'file-no-autosave': {
         hint: "let user know they can't autosave, and there's no cloud storage. Keep short so fits on one line",
         original: 'No autosave, no cloud storage',
-        value: '不能自動保存，沒有云存儲'
+        value: '不能自動保存，沒有雲端儲存'
     },
     'file-new': {
         original: 'New',


### PR DESCRIPTION
Translated the added items into Japanese and Traditional Chinese.
I also adjusted the Simplified Chinese translation to be the same as Traditional Chinese.
This is because Simplified Chinese and Traditional Chinese basically have the same word, only the shape of the letters is different.
For verification, I installed the Simplified Chinese version of Paint Tool SAI and used it as a reference.
- Clipboard.

[剪贴板 - 维基百科，自由的百科全书](https://zh.wikipedia.org/wiki/%E5%89%AA%E8%B4%B4%E6%9D%BF)
"剪贴板" and "剪贴簿" are posted on Wikipedia.
Also, The term used in Simplified Chinese version of Paint Tool SAI is "剪贴板".

- "至" and "到" have the same meaning.
"至" is a formal expression.

- Brush size
The term used in Simplified Chinese version of Paint Tool SAI is  "画笔大小"

- Blending
The term used in Simplified Chinese version of Paint Tool SAI is  "水分量"

- submit
[Google 翻訳](https://translate.google.co.jp/?hl=ja&sl=zh-CN&tl=en&text=%3Cinput%20type%3D%22submit%22%20value%3D%22%E9%80%81%E5%87%BA%22%20name%3D%22submit%22%3E&op=translate)
There is also a "送出" in the Chinese HTML example.
Traditional Chinese, which was translated the other day, also uses "送出". 

- Copied
The English translation of the "已粘贴" is probably "paste".
The translation of Traditional Chinese is "已複製", so I replaced it with Simplified Chinese.
Simplified Chinese "已复制".

Please tell me your opinion.