### PR TITLE
Translation of untranslated parts of Japanese and Traditional Chinese and LANG('shape-line-width')

### DIFF
--- a/src/app/script/klecks/filters/filter-grid.ts
+++ b/src/app/script/klecks/filters/filter-grid.ts
@@ -127,7 +127,7 @@ export const filterGrid = {
             yInput,
         );
         line2.append(
-            BB.el({content: LANG('brush-size') + ':', css: labelStyle}),
+            BB.el({content: LANG('shape-line-width') + ':', css: labelStyle}),
             thicknessInput,
             BB.el({css:{flexGrow: '1'}}),
             colorOptions.getElement(),

--- a/src/app/script/klecks/filters/filter-vanish-point.ts
+++ b/src/app/script/klecks/filters/filter-vanish-point.ts
@@ -147,7 +147,7 @@ export const filterVanishPoint = {
             yInput,
         );
         line2.append(
-            BB.el({content: LANG('brush-size') + ':', css: labelStyle}),
+            BB.el({content: LANG('shape-line-width') + ':', css: labelStyle}),
             thicknessInput,
             BB.el({css:{flexGrow: '1'}}),
             colorOptions.getElement(),

--- a/src/languages/ja.json5
+++ b/src/languages/ja.json5
@@ -950,20 +950,20 @@
   },
   'filter-vanish-point': {
     original: 'Vanish Point',
-    value: ''
+    value: '集中線'
   },
   'filter-vanish-point-title': {
     original: 'Vanishing Point',
-    value: ''
+    value: '集中線'
   },
   'filter-vanish-point-description': {
     original: 'Adds vanishing point to selected layer. Drag preview to move.',
-    value: ''
+    value: '選択レイヤーに集中線を追加します。プレビューはドラッグできます。'
   },
   'filter-vanish-point-lines': {
     hint: 'As in: the number of lines',
     original: 'Lines',
-    value: ''
+    value: '線の数'
   },
   'import-opening': {
     original: 'Opening file...',

--- a/src/languages/zh-TW.json5
+++ b/src/languages/zh-TW.json5
@@ -950,20 +950,20 @@
   },
   'filter-vanish-point': {
     original: 'Vanish Point',
-    value: ''
+    value: '消失點'
   },
   'filter-vanish-point-title': {
     original: 'Vanishing Point',
-    value: ''
+    value: '消失點'
   },
   'filter-vanish-point-description': {
     original: 'Adds vanishing point to selected layer. Drag preview to move.',
-    value: ''
+    value: '添加消失點至所選圖層。'
   },
   'filter-vanish-point-lines': {
     hint: 'As in: the number of lines',
     original: 'Lines',
-    value: ''
+    value: '線條數量'
   },
   'import-opening': {
     original: 'Opening file...',


### PR DESCRIPTION
Translation of untranslated parts of Japanese and Traditional Chinese.
The direct translation of "Vanishing Point" is ｢消失点｣, but I translated it as "集中線".
This is because the operation is closer to the operation of the concentrated line ruler than the vanishing point ruler of MediBang Paint. Or, in the case of Japanese people, I thought that concentration lines would be more intuitive.
If it is absolutely necessary to make it a '消失点'(vanishing point), I will correct the translation.

- `filter-grid.ts`
- `filter-vanish-point.ts`

I thought it would be better to use the 'shape-line-width'.
For these two filters, 'shape-line-width' gives better translation results, so I changed it and made a pull request.
Because the Chinese translation will be a better translation.

Please let me know your opinion.
