### PR TITLE
Add link to video tutorial

### DIFF
--- a/src/help.html
+++ b/src/help.html
@@ -311,6 +311,14 @@
     </div>
     <div class="help-block">
         <div>
+            <h3 class="mt0">Video Tutorial</h3>
+            <a href="https://www.youtube.com/watch?v=1Xdh3X9bVE0" target="_blank" rel="noopener noreferrer">▶️ Kleki - Introduction Tutorial (2022)</a><br>
+            <b>This tutorial is for Kleki, but most of it also applies to Klecks.</b><br>
+            This video gives you an overview and teaches you how to use the most important features, including: paint bucket, layers, shortcuts, text tool, and more.<br>
+        </div>
+    </div>
+    <div class="help-block">
+        <div>
             <h3 class="mt0">Shortcuts</h3>
             <ul class="help-ul">
                 <li>


### PR DESCRIPTION
Added a link to Kleki's official tutorial on the help page.

![image](https://user-images.githubusercontent.com/870828/195437301-267d995a-3c11-4ad6-96f0-947a4179a766.png)

@satopian What do you think about this? Is it too confusing that the tutorial is for Kleki?