### PR TITLE
Translation of untranslated parts of Japanese and Traditional Chinese.

### DIFF
--- a/src/languages/ja.json5
+++ b/src/languages/ja.json5
@@ -272,15 +272,15 @@
   },
   'layers-active-layer-visible': {
     original: 'Active layer is visible',
-    value: ''
+    value: 'レイヤー表示中'
   },
   'layers-active-layer-hidden': {
     original: 'Active layer is hidden',
-    value: ''
+    value: 'レイヤー非表示中'
   },
   'layers-visibility-toggle': {
     original: 'Layer Visibility',
-    value: ''
+    value: 'レイヤー表示/非表示'
   },
   'layers-blend-normal': {
     original: 'normal',
@@ -1309,7 +1309,7 @@
   'backup-drawing': {
     hint: '(Embed) If the upload failed, the user can backup/download their drawing.',
     original: 'You can backup your drawing.',
-    value: ''
+    value: '画像をバックアップできます。'
   },
   submit: {
     original: 'Submit',

--- a/src/languages/zh-TW.json5
+++ b/src/languages/zh-TW.json5
@@ -109,7 +109,7 @@
   },
   'brush-size': {
     original: 'Size',
-    value: '畫筆大小'
+    value: '筆刷大小'
   },
   'brush-blending': {
     hint: 'Wetness. How much colors will bleed into each other.',
@@ -272,15 +272,15 @@
   },
   'layers-active-layer-visible': {
     original: 'Active layer is visible',
-    value: ''
+    value: '當前圖層可見'
   },
   'layers-active-layer-hidden': {
     original: 'Active layer is hidden',
-    value: ''
+    value: '當前圖層隱藏'
   },
   'layers-visibility-toggle': {
     original: 'Layer Visibility',
-    value: ''
+    value: '圖層可見性'
   },
   'layers-blend-normal': {
     original: 'normal',
@@ -422,7 +422,7 @@
   },
   'file-format': {
     original: 'File Format',
-    value: ''
+    value: '檔案格式'
   },
   'file-copy': {
     hint: 'verb',
@@ -1309,7 +1309,7 @@
   'backup-drawing': {
     hint: '(Embed) If the upload failed, the user can backup/download their drawing.',
     original: 'You can backup your drawing.',
-    value: ''
+    value: '您可以備份繪圖。'
   },
   submit: {
     original: 'Submit',
@@ -1364,15 +1364,15 @@
   },
   'settings-theme': {
     original: 'Theme',
-    value: ''
+    value: '外觀主題'
   },
   'theme-dark': {
     original: 'Dark',
-    value: ''
+    value: '深色'
   },
   'theme-light': {
     original: 'Light',
-    value: ''
+    value: '淺色'
   },
   'terms-of-service': {
     original: 'Terms of Service',


### PR DESCRIPTION
### zh-TW.json5
```
  'brush-size': {
    original: 'Size',
    value: '筆刷大小'
  },

```
[Adobe Photoshop 中的預設鍵盤快速鍵](https://helpx.adobe.com/tw/photoshop/using/default-keyboard-shortcuts.html)
```
 'file-format': {
    original: 'File Format',
    value: '檔案格式'
 },
```
[Adobe Photoshop 中的檔案格式](https://helpx.adobe.com/tw/photoshop/using/file-formats.html)

The above two were translated with reference to the Photoshop manual.

### ja.json5
 ```
'layers-visibility-toggle': {
    original: 'Layer Visibility',
    value: 'レイヤー表示/非表示'
  },
 
```
The literal translation is "レイヤーの可視性", but the word "可視性" is
is not common, so I translated it as "表示/非表示(show/hide)".
Please tell me your opinion.