### PR TITLE
Add embed parameter and app option enableImageImport

### DIFF
--- a/src/app/script/app/kl-app.ts
+++ b/src/app/script/app/kl-app.ts
@@ -73,6 +73,7 @@ importFilters();
 
 type KlAppOptionsEmbed = {
     url: string;
+    enableImageImport: boolean;
     onSubmit: (onSuccess: () => void, onError: () => void) => void;
 };
 
@@ -1877,7 +1878,7 @@ export class KlApp {
             },
         );
 
-        if (!this.embed) {
+        if (!this.embed || this.embed.enableImageImport) {
             new KL.KlImageDropper({
                 target: document.body,
                 onDrop: (files, optionStr) => {

--- a/src/app/script/main-embed.ts
+++ b/src/app/script/main-embed.ts
@@ -16,6 +16,7 @@ export interface IEmbedParams {
     bottomBar?: HTMLElement;
     aboutEl?: HTMLElement;
     disableAutoFit?: boolean; // disable automatic Fit to View for small canvases
+    enableImageImport?: boolean
 }
 
 export interface IReadPSD {
@@ -57,6 +58,7 @@ export class Embed {
                 aboutEl: this.p.aboutEl,
                 embed: {
                     url: this.p.embedUrl,
+                    enableImageImport: !!this.p.enableImageImport,
                     onSubmit: this.p.onSubmit,
                 },
             });


### PR DESCRIPTION
The parameter can be used to allow image importing in embed mode.

We are using Klecks in the embed mode, but would like to import images either by copy-pasting or by drag-and-dropping. Setting `enableImageImport: true` in embed params allows this.