### PR TITLE
Fix polygon-clipping import for strict-ESM bundlers

### DIFF
--- a/src/app/script/bb/multi-polygon/apply-polygon-clipping.ts
+++ b/src/app/script/bb/multi-polygon/apply-polygon-clipping.ts
@@ -1,4 +1,4 @@
-import * as polygonClipping from 'polygon-clipping';
+import polygonClipping from 'polygon-clipping';
 import { Geom, MultiPolygon, Ring } from 'polygon-clipping';
 
 // wrapper to catch errors, and offer fallback


### PR DESCRIPTION
Selection boolean ops silently no-op under strict-ESM bundlers (Vite/Rollup): the namespace import of `polygon-clipping` has no callable ops there, and the `try/catch` in `applyPolygonClipping` swallows the failure. One-line switch to the default import fixes it and still works under Parcel.

<details>
<summary>Details</summary>

### Summary

`polygon-clipping` exposes its API as a default export. Under Parcel's CJS interop, `import * as polygonClipping` happens to work, but under strict-ESM bundlers the namespace object has no `union`/`intersection`/... members, so `polygonClipping[operation]` is `undefined`. Because `applyPolygonClipping` wraps the call in `try/catch` with a `[]` fallback, every selection op silently returns an empty multipolygon instead of erroring — selections render nothing with no visible failure.

### Changes

- `src/app/script/bb/multi-polygon/apply-polygon-clipping.ts`: `import * as polygonClipping` → default import. Type-only named imports unchanged.

### Validation

- Runtime check under Node ESM: namespace import → `union` is `undefined`; default import → `union` is a function.
- `tsc --noEmit` clean; `npm run build:embed` succeeds.
- Reproduced the silent-selection failure in an app embedding Klecks via a strict-ESM bundler; confirmed selections work with this change.

</details>