### PR TITLE
Ignore easel key shortcuts while an input is focused

### DIFF
--- a/src/app/script/klecks/ui/easel/easel.ts
+++ b/src/app/script/klecks/ui/easel/easel.ts
@@ -494,7 +494,7 @@ export class Easel<GToolId extends string> {
 
         this.keyListener = new KeyListener({
             onDown: (keyStr, e, comboStr, isRepeat) => {
-                if (this.isFrozen) {
+                if (this.isFrozen || BB.isInputFocused(true)) {
                     return;
                 }
 


### PR DESCRIPTION
Typing in a text field can trigger easel tool shortcuts (`r` rotate, `z`, `+`/`-` zoom, arrow keys). This applies the same `BB.isInputFocused(true)` guard that `kl-app.ts`'s key handler already uses to the easel's own `KeyListener`.

<details>
<summary>Details</summary>

### Summary

The app-level key handler in `kl-app.ts` early-returns on `BB.isInputFocused(true)`, but `Easel`'s `KeyListener` `onDown`/`onUp` callbacks only guard on `this.isFrozen`. Any focused text input that coexists with the easel — dialogs, or fields on a page embedding Klecks — lets single-key shortcuts reach the easel while typing.

### Changes

- `src/app/script/klecks/ui/easel/easel.ts`: extend both `onDown` and `onUp` early-return guards to `this.isFrozen || BB.isInputFocused(true)`, matching the existing convention in `kl-app.ts`.

### Validation

- Reproduced in an app embedding Klecks with metadata text fields on the same page: typing `r` rotated the canvas; with this change, typing is inert to the easel while focus is in an input.
- `tsc --noEmit` shows no new errors for `easel.ts`.

</details>