### PR TITLE
Match ProjectViewport render transform order to createMatrixFromTransform

### DIFF
--- a/src/app/script/klecks/ui/project-viewport/project-viewport.ts
+++ b/src/app/script/klecks/ui/project-viewport/project-viewport.ts
@@ -192,12 +192,8 @@ export class ProjectViewport {
         }
 
         // this.ctx.scale(this.resFactor, this.resFactor);
-        // Order (translate, rotate, scale) must match createMatrixFromTransform, which is
-        // used below for the background pattern and function-layer draws. They diverge only
-        // when scale is non-uniform (scaleX !== scaleY) and rotated; keep them consistent.
-        this.ctx.translate(renderedTransform.x, renderedTransform.y);
-        this.ctx.rotate((renderedTransform.angleDeg / 180) * Math.PI);
-        this.ctx.scale(renderedTransform.scaleX, renderedTransform.scaleY);
+        // same matrix as the background pattern and function-layer draws below
+        this.ctx.transform(...matrixToTuple(renderedMat));
 
         if (this.drawBackground) {
             this.ctx.save();

--- a/src/app/script/klecks/ui/project-viewport/project-viewport.ts
+++ b/src/app/script/klecks/ui/project-viewport/project-viewport.ts
@@ -192,9 +192,12 @@ export class ProjectViewport {
         }
 
         // this.ctx.scale(this.resFactor, this.resFactor);
+        // Order (translate, rotate, scale) must match createMatrixFromTransform, which is
+        // used below for the background pattern and function-layer draws. They diverge only
+        // when scale is non-uniform (scaleX !== scaleY) and rotated; keep them consistent.
         this.ctx.translate(renderedTransform.x, renderedTransform.y);
-        this.ctx.scale(renderedTransform.scaleX, renderedTransform.scaleY);
         this.ctx.rotate((renderedTransform.angleDeg / 180) * Math.PI);
+        this.ctx.scale(renderedTransform.scaleX, renderedTransform.scaleY);
 
         if (this.drawBackground) {
             this.ctx.save();


### PR DESCRIPTION
Raster layers on a rotated, non-square canvas draw on a slightly different transform than the background and function-layers. `render()` composed `translate → scale → rotate`; everything else uses `createMatrixFromTransform`'s `translate → rotate → scale`. Apply the same matrix everywhere.

<details>
<summary>Details</summary>

## Summary

`ProjectViewport.render()` builds its canvas transform imperatively as `translate → scale → rotate`, but `createMatrixFromTransform` composes `translate → rotate → scale` — which is the order the same method uses for the background pattern (`inverse(renderedMat)`) and function-layer draws (`compose(renderedMat, ...)`), and the order documented in the class header comment.

The two agree only when scale is uniform (a scalar commutes with rotation). But `fixScale()` derives `scaleX` from the canvas width and `scaleY` from the height, so on any non-square canvas `scaleX !== scaleY`, and a rotated view then draws the raster layers on a slightly different transform than the background pattern and function-layers.

## Changes

- `project-viewport.ts`: apply the viewport transform in `render()` via `ctx.transform(...matrixToTuple(renderedMat))` — the same matrix already used for the background pattern and function-layer draws — instead of imperative `translate`/`scale`/`rotate` calls.

## Commits

1. Minimal fix: reorder the imperative `ctx` calls to `translate, rotate, scale` to match `createMatrixFromTransform`.
2. Follow-up: apply the transform via `ctx.transform(...matrixToTuple(renderedMat))`, so the raster-layer transform provably shares the matrix used for the background pattern and function-layer draws and the orders can't drift apart again. Uses `ctx.transform` (not `setTransform`) so it composes with any prior ctx state.

## Validation

- Matrix check: `translate → rotate → scale` equals `createMatrixFromTransform` for a non-uniform, rotated sample; the old order does not; both agree under uniform scale. No change at `angleDeg === 0` (rotate is identity) or under uniform scale — the correction is sub-pixel under rotation.
- Full Parcel build (`lang:build` + `build`) passes on the final branch state.

</details>
